### PR TITLE
removes stderr redirection for terraform

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -621,14 +621,14 @@ EOL
   output=$(terraform output -json)
   if echo "${output}" | grep -q '"instance_ips"'; then
     debugr "Previous instances found in Terraform output. Proceeding to destroy existing resources..."
-    # terraform destroy -auto-approve &>/dev/null
+    # terraform destroy -auto-approve >/dev/null
     debugr "Please remove the previous install by running ${blue}terraform destroy -auto-approve${reset}"
     exit 1
   fi
 
   # Initialize Terraform
   debug "Initializing Terraform..."
-  terraform init &>/dev/null
+  terraform init >/dev/null
   if [ $? -ne 0 ]; then
     debugr "Terraform initialization failed. Exiting."
     exit 1


### PR DESCRIPTION
Terraform errors are being discarded due to full stdout/stderr suppression. this removes the `stderr` redirection from the terraform commands so users can actually see why terraform apply failed.

**Before:**

```
[DEBUG] Initializing Terraform...
[DEBUG] Applying Terraform configuration...
[DEBUG] Terraform apply failed. Exiting.
```
**After:**
```
[DEBUG] Creating Terraform configuration files...
[DEBUG] Initializing Terraform...
[DEBUG] Applying Terraform configuration...
╷
│ Error: Error resolving image name 'ubuntu-os-cloud/ubuntu-minimal-2004-lts': Could not find image or family ubuntu-os-cloud/ubuntu-minimal-2004-lts
│ 
│   with google_compute_instance.vm_instance[0],
│   on main.tf line 31, in resource "google_compute_instance" "vm_instance":
│   31: resource "google_compute_instance" "vm_instance" {
│ 
╵
[DEBUG] Terraform apply failed. Exiting.
```